### PR TITLE
Fix expand stutter

### DIFF
--- a/KMAccordionTableViewController.xcodeproj/project.pbxproj
+++ b/KMAccordionTableViewController.xcodeproj/project.pbxproj
@@ -47,10 +47,11 @@
 		144BCBFE198278DC009D3E5C /* facebook_email.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = facebook_email.png; sourceTree = "<group>"; };
 		144BCBFF198278DC009D3E5C /* linkdin_Email.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = linkdin_Email.png; sourceTree = "<group>"; };
 		144BCC00198278DC009D3E5C /* Skype_Email.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Skype_Email.png; sourceTree = "<group>"; };
-		38CD84FE5C9546799E339B87 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
 		58A2F813C2DB48A6ACECC1AD /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		64508BBD9ECAFBCCE08B0968 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		6F488A7756D3B290E2C1C9C3 /* KMAppearence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KMAppearence.h; sourceTree = "<group>"; };
 		6F488B930B10737E789F36D8 /* KMAppearence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KMAppearence.m; sourceTree = "<group>"; };
+		7F981DA421B13FBF2DEAECAC /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		BE6DEF6119180BD4008490FC /* KMAccordionTableViewController.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KMAccordionTableViewController.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE6DEF6419180BD4008490FC /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		BE6DEF6619180BD4008490FC /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -105,6 +106,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		06339D168DEB1FFE42154C43 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				7F981DA421B13FBF2DEAECAC /* Pods.debug.xcconfig */,
+				64508BBD9ECAFBCCE08B0968 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		BE6DEF5819180BD3008490FC = {
 			isa = PBXGroup;
 			children = (
@@ -112,7 +122,7 @@
 				BE6DEF8319180BD9008490FC /* KMAccordionTableViewControllerTests */,
 				BE6DEF6319180BD4008490FC /* Frameworks */,
 				BE6DEF6219180BD4008490FC /* Products */,
-				38CD84FE5C9546799E339B87 /* Pods.xcconfig */,
+				06339D168DEB1FFE42154C43 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -344,7 +354,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E7099655EADC44B9A90A4D4E /* Check Pods Manifest.lock */ = {
@@ -489,7 +499,7 @@
 		};
 		BE6DEF8E19180BD9008490FC /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 38CD84FE5C9546799E339B87 /* Pods.xcconfig */;
+			baseConfigurationReference = 7F981DA421B13FBF2DEAECAC /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -503,7 +513,7 @@
 		};
 		BE6DEF8F19180BD9008490FC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 38CD84FE5C9546799E339B87 /* Pods.xcconfig */;
+			baseConfigurationReference = 64508BBD9ECAFBCCE08B0968 /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/KMAccordionTableViewController/Classes/Header/KMSectionHeaderView.xib
+++ b/KMAccordionTableViewController/Classes/Header/KMSectionHeaderView.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6154.17" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6153.11"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="KMTableViewController"/>
@@ -15,7 +16,7 @@
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mmV-0D-x5a">
-                    <rect key="frame" x="272" y="0.0" width="47" height="47"/>
+                    <rect key="frame" x="280" y="0.0" width="30" height="47"/>
                     <state key="normal">
                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                     </state>
@@ -24,13 +25,10 @@
                     </connections>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vo7-QZ-Maa">
-                    <rect key="frame" x="0.0" y="0.0" width="271" height="47"/>
+                    <rect key="frame" x="0.0" y="0.0" width="53" height="47"/>
                     <subviews>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbG-Fq-5Ap">
-                            <rect key="frame" x="13" y="14" width="260" height="21"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="260" id="G4M-3O-jHZ"/>
-                            </constraints>
+                            <rect key="frame" x="13" y="14" width="42" height="21"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                             <nil key="highlightedColor"/>
@@ -54,7 +52,7 @@
             </subviews>
             <constraints>
                 <constraint firstItem="WJA-Jn-ogR" firstAttribute="top" secondItem="Vo7-QZ-Maa" secondAttribute="bottom" id="4Qu-o0-Yme"/>
-                <constraint firstItem="mmV-0D-x5a" firstAttribute="leading" secondItem="Vo7-QZ-Maa" secondAttribute="trailing" constant="1" id="5Na-kb-X4e"/>
+                <constraint firstItem="mmV-0D-x5a" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Vo7-QZ-Maa" secondAttribute="trailing" constant="1" id="5Na-kb-X4e"/>
                 <constraint firstAttribute="trailing" secondItem="WJA-Jn-ogR" secondAttribute="trailing" id="FOF-Pu-8oD"/>
                 <constraint firstItem="Vo7-QZ-Maa" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Fxj-QY-Ooa"/>
                 <constraint firstItem="Vo7-QZ-Maa" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="KgM-aw-e97"/>
@@ -65,11 +63,12 @@
                 <constraint firstAttribute="bottom" secondItem="WJA-Jn-ogR" secondAttribute="bottom" id="jOb-JD-lBg"/>
                 <constraint firstItem="Uju-4A-bTW" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="pOd-6y-ByL"/>
                 <constraint firstItem="mmV-0D-x5a" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="qAR-0U-uvq"/>
-                <constraint firstItem="mmV-0D-x5a" firstAttribute="leading" secondItem="Vo7-QZ-Maa" secondAttribute="trailing" constant="1" id="rr7-yt-g5D"/>
+                <constraint firstItem="mmV-0D-x5a" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Vo7-QZ-Maa" secondAttribute="trailing" constant="1" id="rr7-yt-g5D"/>
                 <constraint firstAttribute="bottom" secondItem="mmV-0D-x5a" secondAttribute="bottom" constant="1" id="waQ-G6-F9L"/>
                 <constraint firstItem="WJA-Jn-ogR" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="xO7-xy-4qU"/>
-                <constraint firstAttribute="trailing" secondItem="mmV-0D-x5a" secondAttribute="trailing" constant="1" id="zfN-lx-Z8D"/>
+                <constraint firstAttribute="trailing" secondItem="mmV-0D-x5a" secondAttribute="trailing" constant="10" id="zfN-lx-Z8D"/>
             </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="backgroundHeaderView" destination="Uju-4A-bTW" id="n6s-hd-JAo"/>
@@ -80,4 +79,9 @@
             </connections>
         </view>
     </objects>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
 </document>

--- a/KMAccordionTableViewController/Classes/Header/KMSectionHeaderView.xib
+++ b/KMAccordionTableViewController/Classes/Header/KMSectionHeaderView.xib
@@ -24,26 +24,18 @@
                         <action selector="toggleOpen:" destination="iN0-l3-epB" eventType="touchUpInside" id="wbL-fa-FJZ"/>
                     </connections>
                 </button>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vo7-QZ-Maa">
-                    <rect key="frame" x="0.0" y="0.0" width="53" height="47"/>
-                    <subviews>
-                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbG-Fq-5Ap">
-                            <rect key="frame" x="13" y="14" width="42" height="21"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <constraints>
-                        <constraint firstItem="cbG-Fq-5Ap" firstAttribute="leading" secondItem="Vo7-QZ-Maa" secondAttribute="leading" constant="13" id="1k4-Co-mBx"/>
-                        <constraint firstAttribute="centerX" secondItem="cbG-Fq-5Ap" secondAttribute="centerX" constant="-7.5" id="5M2-57-JHa"/>
-                        <constraint firstItem="cbG-Fq-5Ap" firstAttribute="centerY" secondItem="Vo7-QZ-Maa" secondAttribute="centerY" constant="1" id="pwe-ya-TVy"/>
-                    </constraints>
-                </view>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbG-Fq-5Ap">
+                    <rect key="frame" x="139" y="14" width="42" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WJA-Jn-ogR">
                     <rect key="frame" x="0.0" y="47" width="320" height="1"/>
                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="1" id="2x4-0I-tCS"/>
+                    </constraints>
                 </view>
                 <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wkr-Fq-D4M">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="48"/>
@@ -51,19 +43,15 @@
                 </view>
             </subviews>
             <constraints>
-                <constraint firstItem="WJA-Jn-ogR" firstAttribute="top" secondItem="Vo7-QZ-Maa" secondAttribute="bottom" id="4Qu-o0-Yme"/>
-                <constraint firstItem="mmV-0D-x5a" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Vo7-QZ-Maa" secondAttribute="trailing" constant="1" id="5Na-kb-X4e"/>
                 <constraint firstAttribute="trailing" secondItem="WJA-Jn-ogR" secondAttribute="trailing" id="FOF-Pu-8oD"/>
-                <constraint firstItem="Vo7-QZ-Maa" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Fxj-QY-Ooa"/>
-                <constraint firstItem="Vo7-QZ-Maa" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="KgM-aw-e97"/>
+                <constraint firstAttribute="centerY" secondItem="cbG-Fq-5Ap" secondAttribute="centerY" id="HJI-80-fBk"/>
                 <constraint firstAttribute="trailing" secondItem="Uju-4A-bTW" secondAttribute="trailing" id="QFO-Je-nvv"/>
-                <constraint firstAttribute="bottom" secondItem="Vo7-QZ-Maa" secondAttribute="bottom" constant="1" id="RKk-28-wcw"/>
                 <constraint firstAttribute="bottom" secondItem="Uju-4A-bTW" secondAttribute="bottom" id="S1A-25-Iam"/>
                 <constraint firstItem="Uju-4A-bTW" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="i5S-M0-lXu"/>
                 <constraint firstAttribute="bottom" secondItem="WJA-Jn-ogR" secondAttribute="bottom" id="jOb-JD-lBg"/>
+                <constraint firstAttribute="centerX" secondItem="cbG-Fq-5Ap" secondAttribute="centerX" id="o9u-go-Ie1"/>
                 <constraint firstItem="Uju-4A-bTW" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="pOd-6y-ByL"/>
                 <constraint firstItem="mmV-0D-x5a" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="qAR-0U-uvq"/>
-                <constraint firstItem="mmV-0D-x5a" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Vo7-QZ-Maa" secondAttribute="trailing" constant="1" id="rr7-yt-g5D"/>
                 <constraint firstAttribute="bottom" secondItem="mmV-0D-x5a" secondAttribute="bottom" constant="1" id="waQ-G6-F9L"/>
                 <constraint firstItem="WJA-Jn-ogR" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="xO7-xy-4qU"/>
                 <constraint firstAttribute="trailing" secondItem="mmV-0D-x5a" secondAttribute="trailing" constant="10" id="zfN-lx-Z8D"/>

--- a/KMAccordionTableViewController/Classes/ViewController/KMAccordionTableViewController.h
+++ b/KMAccordionTableViewController/Classes/ViewController/KMAccordionTableViewController.h
@@ -17,6 +17,7 @@
 
 @protocol KMAccordionTableViewControllerDelegate <NSObject>
 
+@optional
 - (void)accordionTableViewControllerSectionDidOpen:(KMSection *)section;
 - (void)accordionTableViewControllerSectionDidChangeOpen:(KMSection *)section;
 - (void)accordionTableViewControllerSectionDidClose:(KMSection *)section;

--- a/KMAccordionTableViewController/Classes/ViewController/KMAccordionTableViewController.h
+++ b/KMAccordionTableViewController/Classes/ViewController/KMAccordionTableViewController.h
@@ -17,8 +17,9 @@
 
 @protocol KMAccordionTableViewControllerDelegate <NSObject>
 
-- (void)accordionTableViewControllerSectionDidOpened:(KMSection *)section;
-- (void)accordionTableViewControllerSectionDidClosed:(KMSection *)section;
+- (void)accordionTableViewControllerSectionDidOpen:(KMSection *)section;
+- (void)accordionTableViewControllerSectionDidChangeOpen:(KMSection *)section;
+- (void)accordionTableViewControllerSectionDidClose:(KMSection *)section;
 
 @end
 

--- a/KMAccordionTableViewController/Classes/ViewController/KMAccordionTableViewController.m
+++ b/KMAccordionTableViewController/Classes/ViewController/KMAccordionTableViewController.m
@@ -214,7 +214,6 @@ static bool oneSectionAlwaysOpen = NO;
     }
     self.openSectionIndex = sectionOpened;
 
-    [self.tableView reloadData];
 }
 
 - (void)sectionHeaderView:(KMSectionHeaderView *)sectionHeaderView sectionClosed:(NSInteger)sectionClosed {

--- a/KMAccordionTableViewController/Classes/ViewController/KMAccordionTableViewController.m
+++ b/KMAccordionTableViewController/Classes/ViewController/KMAccordionTableViewController.m
@@ -179,9 +179,8 @@ static bool oneSectionAlwaysOpen = NO;
 
 #pragma mark - SectionHeaderViewDelegate
 
-- (void)sectionHeaderView:(KMSectionHeaderView *)sectionHeaderView selectedSectionAtIndex:(NSInteger)sectionOpened
-{
-    
+- (void)sectionHeaderView:(KMSectionHeaderView *)sectionHeaderView selectedSectionAtIndex:(NSInteger)sectionOpened {
+
     KMSection *section = (self.sections)[sectionOpened];
     
     if (!section.open) {
@@ -209,9 +208,16 @@ static bool oneSectionAlwaysOpen = NO;
         KMSection *previousOpenSection = (self.sections)[previousOpenSectionIndex];
         previousOpenSection.open = NO;
         [indexPathsToDelete addObject:[NSIndexPath indexPathForRow:0 inSection:previousOpenSectionIndex]];
-        if ([self.delegate respondsToSelector:@selector(accordionTableViewControllerSectionDidClosed:)]) {
-            KMSection *previuosSection = (self.sections)[previousOpenSectionIndex];
-            [self.delegate accordionTableViewControllerSectionDidClosed:previuosSection];
+
+        if ([self.delegate respondsToSelector:@selector(accordionTableViewControllerSectionDidChangeOpen:)]) {
+            [self.delegate accordionTableViewControllerSectionDidChangeOpen:section];
+        }
+    }
+    else {
+        self.openSectionIndex = sectionOpened;
+
+        if ([self.delegate respondsToSelector:@selector(accordionTableViewControllerSectionDidOpen:)]) {
+            [self.delegate accordionTableViewControllerSectionDidOpen:section];
         }
     }
     
@@ -219,15 +225,6 @@ static bool oneSectionAlwaysOpen = NO;
     [self.tableView insertRowsAtIndexPaths:indexPathsToInsert withRowAnimation:UITableViewRowAnimationFade];
     [self.tableView deleteRowsAtIndexPaths:indexPathsToDelete withRowAnimation:UITableViewRowAnimationFade];
     [self.tableView endUpdates];
-    
-    CGRect sectionRect = [self.tableView rectForSection:sectionOpened];
-    [self.tableView scrollRectToVisible:sectionRect animated:YES];
-    
-    self.openSectionIndex = sectionOpened;
-    
-    if ([self.delegate respondsToSelector:@selector(accordionTableViewControllerSectionDidOpened:)]) {
-        [self.delegate accordionTableViewControllerSectionDidOpened:section];
-    }
 }
 
 - (void)sectionHeaderView:(KMSectionHeaderView *)sectionHeaderView sectionClosed:(NSInteger)sectionClosed {
@@ -240,13 +237,16 @@ static bool oneSectionAlwaysOpen = NO;
     if (countOfRowsToDelete > 0) {
         NSMutableArray *indexPathsToDelete = [[NSMutableArray alloc] init];
         [indexPathsToDelete addObject:[NSIndexPath indexPathForRow:0 inSection:sectionClosed]];
+
+        [self.tableView beginUpdates];
         [self.tableView deleteRowsAtIndexPaths:indexPathsToDelete withRowAnimation:UITableViewRowAnimationFade];
+        [self.tableView endUpdates];
     }
     
     self.openSectionIndex = NSNotFound;
     
-    if ([self.delegate respondsToSelector:@selector(accordionTableViewControllerSectionDidClosed:)]) {
-        [self.delegate accordionTableViewControllerSectionDidClosed:currentSection];
+    if ([self.delegate respondsToSelector:@selector(accordionTableViewControllerSectionDidClose:)]) {
+        [self.delegate accordionTableViewControllerSectionDidClose:currentSection];
     }
 
 }

--- a/KMAccordionTableViewController/Classes/ViewController/KMAccordionTableViewController.m
+++ b/KMAccordionTableViewController/Classes/ViewController/KMAccordionTableViewController.m
@@ -160,6 +160,7 @@ static bool oneSectionAlwaysOpen = NO;
     [sectionHeaderView.imageView setImage:currentSection.image];
     [sectionHeaderView setSection:sectionIndex];
     [sectionHeaderView setDelegate:self];
+    sectionHeaderView.disclosureButton.selected = currentSection.isOpen;
     UIColor *tempcolor = self.sectionAppearence.headerColor;
     if (currentSection.colorForBackground) {
         [self.sectionAppearence setHeaderColor:currentSection.colorForBackground];
@@ -194,61 +195,38 @@ static bool oneSectionAlwaysOpen = NO;
 - (void)sectionHeaderView:(KMSectionHeaderView *)sectionHeaderView sectionOpened:(NSInteger)sectionOpened {
     
     KMSection *section = (self.sections)[sectionOpened];
-    
     section.open = YES;
-    
-    NSMutableArray *indexPathsToInsert = [[NSMutableArray alloc] init];
-    [indexPathsToInsert addObject:[NSIndexPath indexPathForRow:0 inSection:sectionOpened]];
-    
-    NSMutableArray *indexPathsToDelete = [[NSMutableArray alloc] init];
     
     NSInteger previousOpenSectionIndex = self.openSectionIndex;
     
     if (previousOpenSectionIndex != NSNotFound) {
         KMSection *previousOpenSection = (self.sections)[previousOpenSectionIndex];
         previousOpenSection.open = NO;
-        [indexPathsToDelete addObject:[NSIndexPath indexPathForRow:0 inSection:previousOpenSectionIndex]];
 
         if ([self.delegate respondsToSelector:@selector(accordionTableViewControllerSectionDidChangeOpen:)]) {
             [self.delegate accordionTableViewControllerSectionDidChangeOpen:section];
         }
     }
     else {
-        self.openSectionIndex = sectionOpened;
-
         if ([self.delegate respondsToSelector:@selector(accordionTableViewControllerSectionDidOpen:)]) {
             [self.delegate accordionTableViewControllerSectionDidOpen:section];
         }
     }
-    
-    [self.tableView beginUpdates];
-    [self.tableView insertRowsAtIndexPaths:indexPathsToInsert withRowAnimation:UITableViewRowAnimationFade];
-    [self.tableView deleteRowsAtIndexPaths:indexPathsToDelete withRowAnimation:UITableViewRowAnimationFade];
-    [self.tableView endUpdates];
+    self.openSectionIndex = sectionOpened;
+
+    [self.tableView reloadData];
 }
 
 - (void)sectionHeaderView:(KMSectionHeaderView *)sectionHeaderView sectionClosed:(NSInteger)sectionClosed {
     
     KMSection *currentSection = (self.sections)[sectionClosed];
-    
     currentSection.open = NO;
-    NSInteger countOfRowsToDelete = [self.tableView numberOfRowsInSection:sectionClosed];
-    
-    if (countOfRowsToDelete > 0) {
-        NSMutableArray *indexPathsToDelete = [[NSMutableArray alloc] init];
-        [indexPathsToDelete addObject:[NSIndexPath indexPathForRow:0 inSection:sectionClosed]];
-
-        [self.tableView beginUpdates];
-        [self.tableView deleteRowsAtIndexPaths:indexPathsToDelete withRowAnimation:UITableViewRowAnimationFade];
-        [self.tableView endUpdates];
-    }
-    
     self.openSectionIndex = NSNotFound;
     
     if ([self.delegate respondsToSelector:@selector(accordionTableViewControllerSectionDidClose:)]) {
         [self.delegate accordionTableViewControllerSectionDidClose:currentSection];
     }
-
+    [self.tableView reloadData];
 }
 
 @end

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,2 @@
 platform :ios, '6.0'
 
-pod 'Reveal-iOS-SDK'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,1 @@
-PODS:
-  - Reveal-iOS-SDK (1.0.4)
-
-DEPENDENCIES:
-  - Reveal-iOS-SDK
-
-SPEC CHECKSUMS:
-  Reveal-iOS-SDK: d3c8e109d42219daaa7a6e1ad2de34f0bdbb7a88
-
-COCOAPODS: 0.33.1
+COCOAPODS: 0.36.3


### PR DESCRIPTION
Calling class needs to use [tableView reloadData] after section is opened. If we're creating the section's view dynamically, sectionHeaderView:sectionOpened calls reloadData, it doesn't have the full height yet and causes a stutter (see below).

*STUTTERING*

![stutter](https://cloud.githubusercontent.com/assets/2512443/8189937/94198180-142d-11e5-9fa4-6c978755866f.gif)


*FIXED*

![nonstutter](https://cloud.githubusercontent.com/assets/2512443/8189943/9b476a30-142d-11e5-8083-7c6a572beb89.gif)
